### PR TITLE
Sprinkle delight: animated title, divider shimmer, gradient 404

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,16 +4,14 @@ import '../styles/global.css';
 interface Props {
   title: string;
   description?: string;
-  bodyClass?: string;
 }
 
-const { title, description = "Noah Landesberg's personal site.", bodyClass } = Astro.props;
+const { title, description = "Noah Landesberg's personal site." } = Astro.props;
 const pathname = Astro.url.pathname;
 const isActive = (href: string) => pathname === href || (pathname.startsWith(href) && href !== '/');
 
 // Wrap each letter of the site title in its own span so CSS can stagger
-// the per-letter wave + color cascade on hover. A non-breaking space
-// preserves the gap between "Noah" and "Landesberg".
+// the per-letter wave + color cascade on hover.
 const titleLetters = Array.from('Noah Landesberg');
 ---
 
@@ -28,7 +26,7 @@ const titleLetters = Array.from('Noah Landesberg');
     <title>{title}</title>
     <slot name="head" />
   </head>
-  <body class={bodyClass}>
+  <body>
     <div class="page">
       <header class="site-header">
         <h1 class="site-title"><a href="/" aria-label="Noah Landesberg — home">{titleLetters.map((ch, i) => (
@@ -56,109 +54,16 @@ const titleLetters = Array.from('Noah Landesberg');
       <main>
         <slot />
       </main>
-      <footer class="signoff">
-        <span data-signoff>made with care</span>
-      </footer>
     </div>
 
     <script is:inline>
-      // Delight layer — runs alongside the bundled PostHog init below.
-      // Three things: (1) a friendly console greeting with a hint at the
-      // konami easter egg, (2) the konami listener itself, which fires
-      // a "rhyme rain" overlay tying back to the rhymer project, and
-      // (3) a randomized footer signoff so each visit feels a tiny bit
-      // different.
-
-      (function () {
-        const reduceMotion = window.matchMedia &&
-          window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-        // (1) console greeting
-        try {
-          console.log(
-            '%c hello — you found the source. ',
-            'background:#b14545;color:#fdfbf5;font:600 13px/1.6 ui-serif,Georgia,serif;padding:4px 10px;border-radius:2px;'
-          );
-          console.log(
-            '%c try the konami code (↑↑↓↓←→←→ B A) for a small surprise',
-            'color:#888;font:12px ui-monospace,Menlo,monospace;'
-          );
-          console.log(
-            '%c say hi: noah.landesberg@gmail.com',
-            'color:#2d6a6d;font:12px ui-monospace,Menlo,monospace;'
-          );
-        } catch (e) { /* devtools-less environments */ }
-
-        // (3) random footer signoff — picked at runtime so it changes
-        // each visit; falls back to the default if the node is missing.
-        const signoffs = [
-          'made in San Francisco',
-          'sent from a foggy morning',
-          'powered by curiosity (and a little caffeine)',
-          'still tinkering, after all these years',
-          'thanks for stopping by',
-          'this URL has been live since 2017',
-          'built on a quiet weekend',
-          'updated whenever the mood strikes',
-          'with a soft spot for early-internet flavor',
-          'if you read this, you read it'
-        ];
-        const signEl = document.querySelector('[data-signoff]');
-        if (signEl) {
-          signEl.textContent = signoffs[Math.floor(Math.random() * signoffs.length)];
-        }
-
-        // (2) konami listener — ↑↑↓↓←→←→BA
-        const konami = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
-        let pos = 0;
-        document.addEventListener('keydown', (e) => {
-          // ignore typing inside form fields
-          const tag = (e.target && e.target.tagName) || '';
-          if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-
-          const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
-          if (key === konami[pos]) {
-            pos++;
-            if (pos === konami.length) {
-              pos = 0;
-              if (!reduceMotion) rhymeRain();
-            }
-          } else {
-            pos = (key === konami[0]) ? 1 : 0;
-          }
-        });
-
-        function rhymeRain() {
-          // already raining? don't stack
-          if (document.querySelector('.rhyme-rain')) return;
-
-          const words = [
-            'rhyme','chime','dime','lime','time','prime','climb','grime',
-            'mime','sublime','design','aligned','combined','find','mind',
-            'signed','wine','shine','line','divine','behind','outshine',
-            'in time','rewind','refined','assigned','underlined'
-          ];
-          const colors = ['#b14545','#d4a13a','#2d6a6d','#c97b8f','#1a1a1a'];
-
-          const overlay = document.createElement('div');
-          overlay.className = 'rhyme-rain';
-          document.body.appendChild(overlay);
-
-          for (let i = 0; i < 70; i++) {
-            const span = document.createElement('span');
-            span.textContent = words[Math.floor(Math.random() * words.length)];
-            span.style.left = Math.random() * 100 + '%';
-            span.style.color = colors[Math.floor(Math.random() * colors.length)];
-            span.style.animationDuration = (3.2 + Math.random() * 4) + 's';
-            span.style.animationDelay = (Math.random() * 2.4) + 's';
-            span.style.fontSize = (0.9 + Math.random() * 1.6) + 'rem';
-            overlay.appendChild(span);
-          }
-
-          // remove the overlay once the longest-delayed word has fallen
-          setTimeout(() => overlay.remove(), 8500);
-        }
-      })();
+      // Quiet hello in the devtools console for the curious.
+      try {
+        console.log(
+          '%c say hi: noah.landesberg@gmail.com',
+          'color:#2d6a6d;font:12px ui-monospace,Menlo,monospace;'
+        );
+      } catch (e) { /* no console available */ }
     </script>
 
     <script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,11 +4,17 @@ import '../styles/global.css';
 interface Props {
   title: string;
   description?: string;
+  bodyClass?: string;
 }
 
-const { title, description = "Noah Landesberg's personal site." } = Astro.props;
+const { title, description = "Noah Landesberg's personal site.", bodyClass } = Astro.props;
 const pathname = Astro.url.pathname;
 const isActive = (href: string) => pathname === href || (pathname.startsWith(href) && href !== '/');
+
+// Wrap each letter of the site title in its own span so CSS can stagger
+// the per-letter wave + color cascade on hover. A non-breaking space
+// preserves the gap between "Noah" and "Landesberg".
+const titleLetters = Array.from('Noah Landesberg');
 ---
 
 <!doctype html>
@@ -22,10 +28,12 @@ const isActive = (href: string) => pathname === href || (pathname.startsWith(hre
     <title>{title}</title>
     <slot name="head" />
   </head>
-  <body>
+  <body class={bodyClass}>
     <div class="page">
       <header class="site-header">
-        <h1 class="site-title"><a href="/">Noah Landesberg</a></h1>
+        <h1 class="site-title"><a href="/" aria-label="Noah Landesberg — home">{titleLetters.map((ch, i) => (
+          <span style={`--i: ${i}`} aria-hidden="true">{ch === ' ' ? ' ' : ch}</span>
+        ))}</a></h1>
         <nav>
           <a href="/" aria-current={pathname === '/' ? 'page' : undefined}>Home</a>
           <span class="sep">·</span>
@@ -48,7 +56,110 @@ const isActive = (href: string) => pathname === href || (pathname.startsWith(hre
       <main>
         <slot />
       </main>
+      <footer class="signoff">
+        <span data-signoff>made with care</span>
+      </footer>
     </div>
+
+    <script is:inline>
+      // Delight layer — runs alongside the bundled PostHog init below.
+      // Three things: (1) a friendly console greeting with a hint at the
+      // konami easter egg, (2) the konami listener itself, which fires
+      // a "rhyme rain" overlay tying back to the rhymer project, and
+      // (3) a randomized footer signoff so each visit feels a tiny bit
+      // different.
+
+      (function () {
+        const reduceMotion = window.matchMedia &&
+          window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        // (1) console greeting
+        try {
+          console.log(
+            '%c hello — you found the source. ',
+            'background:#b14545;color:#fdfbf5;font:600 13px/1.6 ui-serif,Georgia,serif;padding:4px 10px;border-radius:2px;'
+          );
+          console.log(
+            '%c try the konami code (↑↑↓↓←→←→ B A) for a small surprise',
+            'color:#888;font:12px ui-monospace,Menlo,monospace;'
+          );
+          console.log(
+            '%c say hi: noah.landesberg@gmail.com',
+            'color:#2d6a6d;font:12px ui-monospace,Menlo,monospace;'
+          );
+        } catch (e) { /* devtools-less environments */ }
+
+        // (3) random footer signoff — picked at runtime so it changes
+        // each visit; falls back to the default if the node is missing.
+        const signoffs = [
+          'made in San Francisco',
+          'sent from a foggy morning',
+          'powered by curiosity (and a little caffeine)',
+          'still tinkering, after all these years',
+          'thanks for stopping by',
+          'this URL has been live since 2017',
+          'built on a quiet weekend',
+          'updated whenever the mood strikes',
+          'with a soft spot for early-internet flavor',
+          'if you read this, you read it'
+        ];
+        const signEl = document.querySelector('[data-signoff]');
+        if (signEl) {
+          signEl.textContent = signoffs[Math.floor(Math.random() * signoffs.length)];
+        }
+
+        // (2) konami listener — ↑↑↓↓←→←→BA
+        const konami = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
+        let pos = 0;
+        document.addEventListener('keydown', (e) => {
+          // ignore typing inside form fields
+          const tag = (e.target && e.target.tagName) || '';
+          if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+          const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+          if (key === konami[pos]) {
+            pos++;
+            if (pos === konami.length) {
+              pos = 0;
+              if (!reduceMotion) rhymeRain();
+            }
+          } else {
+            pos = (key === konami[0]) ? 1 : 0;
+          }
+        });
+
+        function rhymeRain() {
+          // already raining? don't stack
+          if (document.querySelector('.rhyme-rain')) return;
+
+          const words = [
+            'rhyme','chime','dime','lime','time','prime','climb','grime',
+            'mime','sublime','design','aligned','combined','find','mind',
+            'signed','wine','shine','line','divine','behind','outshine',
+            'in time','rewind','refined','assigned','underlined'
+          ];
+          const colors = ['#b14545','#d4a13a','#2d6a6d','#c97b8f','#1a1a1a'];
+
+          const overlay = document.createElement('div');
+          overlay.className = 'rhyme-rain';
+          document.body.appendChild(overlay);
+
+          for (let i = 0; i < 70; i++) {
+            const span = document.createElement('span');
+            span.textContent = words[Math.floor(Math.random() * words.length)];
+            span.style.left = Math.random() * 100 + '%';
+            span.style.color = colors[Math.floor(Math.random() * colors.length)];
+            span.style.animationDuration = (3.2 + Math.random() * 4) + 's';
+            span.style.animationDelay = (Math.random() * 2.4) + 's';
+            span.style.fontSize = (0.9 + Math.random() * 1.6) + 'rem';
+            overlay.appendChild(span);
+          }
+
+          // remove the overlay once the longest-delayed word has fallen
+          setTimeout(() => overlay.remove(), 8500);
+        }
+      })();
+    </script>
 
     <script>
       // PostHog cookieless init — no consent banner needed.

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,10 +5,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="404 — Noah Landesberg" description="Page not found.">
   <div class="lost">
     <h1>404</h1>
-    <ul class="lost-links">
-      <li><a href="/">home</a></li>
-      <li><a href="/projects/">projects</a></li>
-      <li><a href="/blog/">writing</a></li>
-    </ul>
+    <p>This page could not be found.</p>
   </div>
 </BaseLayout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,6 +3,30 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="404 — Noah Landesberg" description="Page not found.">
-  <h1>404 — Not Found</h1>
-  <p>That page doesn't exist (or doesn't exist anymore).</p>
+  <div class="lost">
+    <h1>404</h1>
+    <p class="lost-tag" data-lost>this page is somewhere it shouldn't be.</p>
+    <ul class="lost-links">
+      <li><a href="/">home</a></li>
+      <li><a href="/projects/">projects</a></li>
+      <li><a href="/blog/">writing</a></li>
+    </ul>
+  </div>
+
+  <script is:inline>
+    (function () {
+      const messages = [
+        'this page is at large — last seen heading west.',
+        'the URL you tried is on a coffee break.',
+        "you've reached the edge of the website — turn back.",
+        "page not found, but you are. that's something.",
+        'this corner of the internet is empty (for now).',
+        '404 — the page declined the invitation.',
+        'nothing here. but plenty over there →',
+        'the page is in another castle.'
+      ];
+      const el = document.querySelector('[data-lost]');
+      if (el) el.textContent = messages[Math.floor(Math.random() * messages.length)];
+    })();
+  </script>
 </BaseLayout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,28 +5,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="404 — Noah Landesberg" description="Page not found.">
   <div class="lost">
     <h1>404</h1>
-    <p class="lost-tag" data-lost>this page is somewhere it shouldn't be.</p>
     <ul class="lost-links">
       <li><a href="/">home</a></li>
       <li><a href="/projects/">projects</a></li>
       <li><a href="/blog/">writing</a></li>
     </ul>
   </div>
-
-  <script is:inline>
-    (function () {
-      const messages = [
-        'this page is at large — last seen heading west.',
-        'the URL you tried is on a coffee break.',
-        "you've reached the edge of the website — turn back.",
-        "page not found, but you are. that's something.",
-        'this corner of the internet is empty (for now).',
-        '404 — the page declined the invitation.',
-        'nothing here. but plenty over there →',
-        'the page is in another castle.'
-      ];
-      const el = document.querySelector('[data-lost]');
-      if (el) el.textContent = messages[Math.floor(Math.random() * messages.length)];
-    })();
-  </script>
 </BaseLayout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Projects — Noah Landesberg" description="Projects by Noah Landesberg." bodyClass="projects-page">
+<BaseLayout title="Projects — Noah Landesberg" description="Projects by Noah Landesberg.">
   <h2><a class="project-link" href="https://github.com/landesbergn/rhymer">rhymer<span class="arrow">↗</span></a></h2>
   <p>
     An R package to find rhyming words. A wrapper around the

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Projects — Noah Landesberg" description="Projects by Noah Landesberg.">
+<BaseLayout title="Projects — Noah Landesberg" description="Projects by Noah Landesberg." bodyClass="projects-page">
   <h2><a class="project-link" href="https://github.com/landesbergn/rhymer">rhymer<span class="arrow">↗</span></a></h2>
   <p>
     An R package to find rhyming words. A wrapper around the

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -563,13 +563,12 @@ a.project-link:hover .arrow {
 
 /* 404 page polish */
 .lost {
-  text-align: center;
   padding: 2em 0 0;
 }
 
 .lost h1 {
   font-size: 6rem;
-  margin: 0;
+  margin: 0 0 0.2em;
   letter-spacing: -0.04em;
   line-height: 1;
   background: linear-gradient(
@@ -590,28 +589,6 @@ a.project-link:hover .arrow {
 @keyframes lost-drift {
   0%, 100% { background-position:   0% 50%; }
   50%      { background-position: 100% 50%; }
-}
-
-.lost-links {
-  list-style: none;
-  padding: 0;
-  margin: 2.5em 0 0;
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 1.4em;
-  justify-content: center;
-  font-family: var(--font-mono);
-  font-size: 0.9rem;
-}
-
-.lost-links a {
-  border-bottom: 1px solid var(--color-rule);
-  padding-bottom: 2px;
-}
-
-.lost-links a:hover {
-  text-decoration: none;
-  border-bottom-color: var(--color-accent);
 }
 
 /* Respect reduced-motion preferences — kill the title wave, divider

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,8 +3,14 @@
   --color-text: #1a1a1a;           /* near-black, softer on warm bg */
   --color-muted: #6b6b6b;
   --color-rule: #d8d3c3;
-  --color-accent: #b14545;         /* oxblood — used sparingly */
+  --color-accent: #b14545;         /* oxblood — primary accent */
   --color-code-bg: #f1ede1;
+
+  /* Delight palette — used sparingly for per-project flair, the
+     animated divider, and the title's hover cascade. */
+  --accent-mustard: #d4a13a;
+  --accent-teal:    #2d6a6d;
+  --accent-rose:    #c97b8f;
 
   --content-max: 720px;
   --content-wide: 840px;
@@ -71,11 +77,34 @@ body {
 .site-header h1.site-title a {
   color: var(--color-text);
   text-decoration: none;
+  display: inline-block;
 }
 
 .site-header h1.site-title a:hover {
   text-decoration: none;
 }
+
+/* Letter-level wave + color cascade on hover. Each letter is wrapped
+   in its own span and indexed via the inline `--i` custom property,
+   so we can stagger the transition with a per-letter delay. */
+.site-header h1.site-title a span {
+  display: inline-block;
+  transition:
+    transform 0.45s cubic-bezier(.34, 1.56, .64, 1),
+    color 0.45s ease;
+  transition-delay: calc(var(--i, 0) * 22ms);
+  will-change: transform;
+}
+
+.site-header h1.site-title a:hover span {
+  transform: translateY(-6px);
+}
+
+.site-header h1.site-title a:hover span:nth-child(5n+1) { color: var(--color-accent); }
+.site-header h1.site-title a:hover span:nth-child(5n+2) { color: var(--accent-mustard); }
+.site-header h1.site-title a:hover span:nth-child(5n+3) { color: var(--accent-teal); }
+.site-header h1.site-title a:hover span:nth-child(5n+4) { color: var(--accent-rose); }
+.site-header h1.site-title a:hover span:nth-child(5n+5) { color: var(--color-text); }
 
 .site-header nav {
   display: flex;
@@ -278,10 +307,33 @@ hr::before {
   display: block;
   font-family: var(--font-serif);
   letter-spacing: 0.55em;
-  color: var(--color-muted);
   font-size: 1rem;
   /* Compensate for letter-spacing pushing content right of optical center */
   padding-left: 0.55em;
+  /* Slow, ambient color drift across the delight palette — anchored
+     by --color-muted so it spends most of its cycle near the original
+     muted gray and only briefly tints. */
+  background: linear-gradient(
+    90deg,
+    var(--color-muted) 0%,
+    var(--accent-rose) 18%,
+    var(--color-muted) 36%,
+    var(--accent-mustard) 54%,
+    var(--color-muted) 72%,
+    var(--accent-teal) 90%,
+    var(--color-muted) 100%
+  );
+  background-size: 220% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: hr-shimmer 14s linear infinite;
+}
+
+@keyframes hr-shimmer {
+  0%   { background-position:   0% 50%; }
+  100% { background-position: 220% 50%; }
 }
 
 .divider-ascii {
@@ -501,10 +553,146 @@ a.project-link .arrow {
   font-size: 0.6em;
   font-weight: 400;
   vertical-align: 0.4em;
-  transition: transform 0.12s ease;
+  transition: transform 0.32s cubic-bezier(.34, 1.56, .64, 1), color 0.2s ease;
 }
 
 a.project-link:hover .arrow {
-  transform: translate(1px, -1px);
+  transform: translate(4px, -4px) rotate(12deg) scale(1.15);
+}
+
+/* Per-project color identity on the projects page. The H2 vertical
+   bar and the ↗ arrow each take one of the three secondary accents,
+   giving each row its own personality without changing the layout. */
+.projects-page main h2:nth-of-type(1)::before { background: var(--accent-mustard); }
+.projects-page main h2:nth-of-type(2)::before { background: var(--accent-teal); }
+.projects-page main h2:nth-of-type(3)::before { background: var(--accent-rose); }
+
+.projects-page main h2:nth-of-type(1) .arrow { color: var(--accent-mustard); }
+.projects-page main h2:nth-of-type(2) .arrow { color: var(--accent-teal); }
+.projects-page main h2:nth-of-type(3) .arrow { color: var(--accent-rose); }
+
+/* Footer signoff — picked at random on each visit by inline JS. */
+.signoff {
+  margin-top: 5em;
+  padding-top: 1.5em;
+  border-top: 1px dashed var(--color-rule);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--color-muted);
+  text-align: center;
+  letter-spacing: 0.01em;
+}
+
+.signoff [data-signoff]::before { content: "— "; opacity: 0.6; }
+
+/* "Rhyme rain" easter egg — triggered by the konami code. A fixed
+   overlay above all content; words fall from above and fade out. */
+.rhyme-rain {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  overflow: hidden;
+}
+
+.rhyme-rain span {
+  position: absolute;
+  top: -10vh;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 700;
+  white-space: nowrap;
+  user-select: none;
+  animation: rhyme-fall linear forwards;
+}
+
+@keyframes rhyme-fall {
+  0%   { transform: translateY(0)     rotate(0);    opacity: 0; }
+  10%  {                                            opacity: 1; }
+  90%  {                                            opacity: 1; }
+  100% { transform: translateY(115vh) rotate(20deg); opacity: 0; }
+}
+
+/* 404 page polish */
+.lost {
+  text-align: center;
+  padding: 2em 0 0;
+}
+
+.lost h1 {
+  font-size: 6rem;
+  margin: 0;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  background: linear-gradient(
+    135deg,
+    var(--color-accent),
+    var(--accent-mustard),
+    var(--accent-teal),
+    var(--accent-rose)
+  );
+  background-size: 200% 200%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: lost-drift 12s ease-in-out infinite;
+}
+
+@keyframes lost-drift {
+  0%, 100% { background-position:   0% 50%; }
+  50%      { background-position: 100% 50%; }
+}
+
+.lost-tag {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  margin: 0.5em 0 2.5em;
+  min-height: 1.5em;             /* avoid layout shift while JS fills it */
+}
+
+.lost-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 1.4em;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.lost-links a {
+  border-bottom: 1px solid var(--color-rule);
+  padding-bottom: 2px;
+}
+
+.lost-links a:hover {
+  text-decoration: none;
+  border-bottom-color: var(--color-accent);
+}
+
+/* Respect reduced-motion preferences — kill the title wave, divider
+   shimmer, 404 gradient drift, and rhyme rain animation. */
+@media (prefers-reduced-motion: reduce) {
+  .site-header h1.site-title a span,
+  a.project-link .arrow {
+    transition: none;
+  }
+  hr::before {
+    animation: none;
+    background: none;
+    color: var(--color-muted);
+    -webkit-text-fill-color: var(--color-muted);
+  }
+  .lost h1 {
+    animation: none;
+    background: none;
+    color: var(--color-text);
+    -webkit-text-fill-color: var(--color-text);
+  }
+  .rhyme-rain { display: none; }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -100,11 +100,12 @@ body {
   transform: translateY(-6px);
 }
 
-.site-header h1.site-title a:hover span:nth-child(5n+1) { color: var(--color-accent); }
-.site-header h1.site-title a:hover span:nth-child(5n+2) { color: var(--accent-mustard); }
-.site-header h1.site-title a:hover span:nth-child(5n+3) { color: var(--accent-teal); }
-.site-header h1.site-title a:hover span:nth-child(5n+4) { color: var(--accent-rose); }
-.site-header h1.site-title a:hover span:nth-child(5n+5) { color: var(--color-text); }
+/* 4-color cycle (no ink slot) so every letter — including the trailing
+   "e" and "g" — picks up a hue. */
+.site-header h1.site-title a:hover span:nth-child(4n+1) { color: var(--color-accent); }
+.site-header h1.site-title a:hover span:nth-child(4n+2) { color: var(--accent-mustard); }
+.site-header h1.site-title a:hover span:nth-child(4n+3) { color: var(--accent-teal); }
+.site-header h1.site-title a:hover span:nth-child(4n+4) { color: var(--accent-rose); }
 
 .site-header nav {
   display: flex;
@@ -560,59 +561,6 @@ a.project-link:hover .arrow {
   transform: translate(4px, -4px) rotate(12deg) scale(1.15);
 }
 
-/* Per-project color identity on the projects page. The H2 vertical
-   bar and the ↗ arrow each take one of the three secondary accents,
-   giving each row its own personality without changing the layout. */
-.projects-page main h2:nth-of-type(1)::before { background: var(--accent-mustard); }
-.projects-page main h2:nth-of-type(2)::before { background: var(--accent-teal); }
-.projects-page main h2:nth-of-type(3)::before { background: var(--accent-rose); }
-
-.projects-page main h2:nth-of-type(1) .arrow { color: var(--accent-mustard); }
-.projects-page main h2:nth-of-type(2) .arrow { color: var(--accent-teal); }
-.projects-page main h2:nth-of-type(3) .arrow { color: var(--accent-rose); }
-
-/* Footer signoff — picked at random on each visit by inline JS. */
-.signoff {
-  margin-top: 5em;
-  padding-top: 1.5em;
-  border-top: 1px dashed var(--color-rule);
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  color: var(--color-muted);
-  text-align: center;
-  letter-spacing: 0.01em;
-}
-
-.signoff [data-signoff]::before { content: "— "; opacity: 0.6; }
-
-/* "Rhyme rain" easter egg — triggered by the konami code. A fixed
-   overlay above all content; words fall from above and fade out. */
-.rhyme-rain {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 9999;
-  overflow: hidden;
-}
-
-.rhyme-rain span {
-  position: absolute;
-  top: -10vh;
-  font-family: var(--font-serif);
-  font-style: italic;
-  font-weight: 700;
-  white-space: nowrap;
-  user-select: none;
-  animation: rhyme-fall linear forwards;
-}
-
-@keyframes rhyme-fall {
-  0%   { transform: translateY(0)     rotate(0);    opacity: 0; }
-  10%  {                                            opacity: 1; }
-  90%  {                                            opacity: 1; }
-  100% { transform: translateY(115vh) rotate(20deg); opacity: 0; }
-}
-
 /* 404 page polish */
 .lost {
   text-align: center;
@@ -644,18 +592,10 @@ a.project-link:hover .arrow {
   50%      { background-position: 100% 50%; }
 }
 
-.lost-tag {
-  font-family: var(--font-mono);
-  font-size: 0.9rem;
-  color: var(--color-muted);
-  margin: 0.5em 0 2.5em;
-  min-height: 1.5em;             /* avoid layout shift while JS fills it */
-}
-
 .lost-links {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 2.5em 0 0;
   display: inline-flex;
   flex-wrap: wrap;
   gap: 1.4em;
@@ -693,6 +633,5 @@ a.project-link:hover .arrow {
     color: var(--color-text);
     -webkit-text-fill-color: var(--color-text);
   }
-  .rhyme-rain { display: none; }
 }
 


### PR DESCRIPTION
## Summary

Keeps the existing site and layout exactly as-is and layers four small UI moments on top — color, motion, and a quiet developer easter egg — to add personality without changing the minimal posture.

### What's new

- **Animated site title** — each letter wraps in its own span; on hover the row lifts in a staggered wave (translateY -6px, ~22ms per-letter delay, springy `cubic-bezier(.34, 1.56, .64, 1)` easing) and cycles through a 4-color cascade (oxblood → mustard → teal → rose, repeating every 4 letters, so every letter — including the trailing `e` and `g` — picks up a hue).
- **Editorial divider (`* * *`)** — slow ambient color shimmer through the delight palette, anchored by the original muted gray for most of the cycle and only briefly tinting. ~14s loop, runs everywhere `<hr>` appears (mostly inside posts).
- **Project arrows (↗)** — the existing oxblood `↗` on `/projects/` now has a more expressive lift on hover: `translate(4px, -4px) rotate(12deg) scale(1.15)` with springy easing. Color stays a single oxblood across all three projects.
- **Simplified 404** — left-aligned, large `404` glyph (6rem) with a gradient fill that drifts across the four-color delight palette (~12s loop), followed by a single line of copy: "This page could not be found." No redundant nav row (the global header already covers that).
- **Devtools easter egg** — a single quiet line: `say hi: noah.landesberg@gmail.com` printed in teal mono. Visible only to anyone who opens the console.

### Color palette

Three secondary accents join oxblood. Used only inside the four moments above:

| name    | hex       | role                                                |
| ------- | --------- | --------------------------------------------------- |
| oxblood | `#b14545` | (primary) title cascade, divider, gradient 404, link hover, ::selection |
| mustard | `#d4a13a` | title cascade, divider drift, gradient 404 |
| teal    | `#2d6a6d` | title cascade, divider drift, gradient 404, console message |
| rose    | `#c97b8f` | title cascade, divider drift, gradient 404 |

### Accessibility

- `prefers-reduced-motion: reduce` disables the title transition, divider shimmer, and 404 gradient drift; falls back to static muted gray / ink colors so the affordances still read.
- Per-letter title spans are `aria-hidden`; the `<a>` carries `aria-label="Noah Landesberg — home"` so screen readers still get the name.
- Console message is a `console.log` — never visible to non-developer users.

## Test plan

- [x] `npm run build` — 11 pages built clean
- [x] Mobile overflow audit at 375px: home / projects / blog / 404 all `documentElement.clientWidth === document.body.scrollWidth === 375` (no horizontal overflow)
- [x] Desktop + mobile screenshots verified for home (rest + title hover), projects (rest + arrow hover), blog index, 404 (left-aligned)
- [x] Reviewer (deploy preview): hover the site title and watch the wave + color cascade
- [x] Reviewer: scroll into a post containing an `<hr>` (e.g. `/blog/post/2020-12-20-2020-lists/`) and watch the `* * *` slowly drift colors
- [x] Reviewer: visit `/projects/` and hover any project name to confirm the `↗` lift + rotate
- [x] Reviewer: visit `/some-bad-url/` to see the left-aligned gradient "404" with "This page could not be found." underneath — verify there is no extra nav row below
- [x] Reviewer: open devtools console on any page to see the teal `say hi:` line
- [x] Reviewer: enable "Reduce motion" in OS settings and reload — title, divider, and 404 should fall back to static styling