### PR TITLE
Skip PostHog's surveys extension on init

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -62,7 +62,8 @@ const isActive = (href: string) => pathname === href || (pathname.startsWith(hre
           capture_pageview: true,          // track pageviews
           autocapture: true,               // track clicks, form submits, link clicks
           capture_exceptions: true,        // track unhandled JS errors
-          disable_session_recording: false // session replay (enable in PostHog UI)
+          disable_session_recording: false, // session replay (enable in PostHog UI)
+          disable_surveys: true            // we don't run surveys; skip the 27 KiB extension
         });
       }
     </script>


### PR DESCRIPTION
## Summary

Adds `disable_surveys: true` to the PostHog init in `src/layouts/BaseLayout.astro`. We don't run surveys, so PostHog's auto-loaded `surveys.js` (27 KiB transfer, all of it unused per Lighthouse) was pure overhead on every page load.

This is the lowest-risk item on the recent Lighthouse "Reduce unused JavaScript" audit. The other two items on that audit (the 25 KiB `posthog-recorder.js` for session replay, and the ~36 KiB unused share of the bundled BaseLayout/PostHog SDK) are deliberate trade-offs / structural to posthog-js, so they're left alone.

## Test plan

- [x] npm run build — 11 pages built clean
- [ ] Reviewer (deploy preview): open devtools → Network and confirm surveys.js no longer loads from us-assets.i.posthog.com after the page settles
- [ ] Reviewer: confirm pageviews + autocapture + session replay still flow through to the PostHog dashboard