### PR TITLE
Flag non-production traffic as $internal_or_test_user

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -82,6 +82,11 @@ const titleLetters = Array.from('Noah Landesberg');
           disable_surveys: true            // we don't run surveys; skip the 27 KiB extension
         });
 
+        // Expose on window so the devtools console can inspect props,
+        // call captures manually, etc. Module-imported posthog is
+        // otherwise scoped to this script and invisible to consumers.
+        window.posthog = posthog;
+
         // Flag non-production traffic (Netlify deploy previews,
         // branch deploys, localhost) as $internal_or_test_user so
         // PostHog's default "Filter internal and test users" toggle

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -81,6 +81,16 @@ const titleLetters = Array.from('Noah Landesberg');
           disable_session_recording: false, // session replay (enable in PostHog UI)
           disable_surveys: true            // we don't run surveys; skip the 27 KiB extension
         });
+
+        // Flag non-production traffic (Netlify deploy previews,
+        // branch deploys, localhost) as $internal_or_test_user so
+        // PostHog's default "Filter internal and test users" toggle
+        // excludes those events from product analytics.
+        const host = window.location.hostname;
+        const isProd = host === 'www.noahlandesberg.com' || host === 'noahlandesberg.com';
+        if (!isProd) {
+          posthog.register({ $internal_or_test_user: true });
+        }
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary

Two related changes to the PostHog setup in `src/layouts/BaseLayout.astro`:

1. **Flag non-production traffic** — adds a runtime hostname check immediately after `posthog.init()`. Anything that isn't the production domain (Netlify deploy previews, branch deploys, localhost dev/preview) calls `posthog.register({ $internal_or_test_user: true })`. PostHog's default **"Filter internal and test users"** toggle then excludes those events from product analytics. Re-registers on every page load, matching the existing `persistence: 'memory'` (cookieless) behavior.

   ```js
   const host = window.location.hostname;
   const isProd = host === 'www.noahlandesberg.com' || host === 'noahlandesberg.com';
   if (!isProd) {
     posthog.register({ $internal_or_test_user: true });
   }
   ```

2. **Expose `posthog` on `window`** — `window.posthog = posthog` after init. Without this, the ES-module import keeps `posthog` scoped to its own bundled script, so the devtools console can't see it (`Uncaught ReferenceError: posthog is not defined`). This makes verification of the flag above a one-liner, and makes future SDK debugging much easier (manual `capture()` calls, inspecting persistence, etc.).

### Why hostname instead of Netlify's `CONTEXT` env var

The hostname check is one source of truth for "is this prod?" — covers Netlify deploy previews, branch deploys, *and* localhost dev/preview without `netlify.toml` plumbing or build-time env-var wiring. Trade-off: the production domain is hardcoded; if the site moves, this needs updating (one line, one place).

## Test plan

- [x] `npm run build` — 11 pages built clean
- [ ] Reviewer (deploy preview): devtools console → `posthog.persistence.props['$internal_or_test_user']` should return `true`
- [ ] Reviewer (production, after merge): same one-liner should return `undefined`
- [ ] Reviewer: confirm an insight in PostHog with "Filter internal and test users" enabled excludes deploy-preview pageviews
