### PR TITLE
Dedupe frozen-post metadata and small quality cleanups

### DIFF
--- a/src/components/FrozenPost.astro
+++ b/src/components/FrozenPost.astro
@@ -1,0 +1,24 @@
+---
+import PostLayout from '../layouts/PostLayout.astro';
+import { stripHeadAssets, type FrozenPost } from '../legacy/posts';
+
+interface Props {
+  post: FrozenPost;
+}
+
+const { post } = Astro.props;
+const cleanedBody = stripHeadAssets(post.body, post.headAssets);
+---
+
+<PostLayout title={post.title} date={post.date} description={post.description}>
+  {post.headAssets.length > 0 && (
+    <Fragment slot="head">
+      {post.headAssets.map((asset) => (
+        asset.type === 'script'
+          ? <script src={asset.href} is:inline></script>
+          : <link href={asset.href} rel="stylesheet" />
+      ))}
+    </Fragment>
+  )}
+  <Fragment set:html={cleanedBody} />
+</PostLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -3,20 +3,19 @@ import BaseLayout from './BaseLayout.astro';
 
 interface Props {
   title: string;
-  date: string | Date;
+  date: Date;
   description?: string;
 }
 
 const { title, date, description } = Astro.props;
-const dateObj = typeof date === 'string' ? new Date(date) : date;
-const isoDate = dateObj.toISOString().slice(0, 10);
+const isoDate = date.toISOString().slice(0, 10);
 ---
 
 <BaseLayout title={`${title} — Noah Landesberg`} description={description}>
   <slot name="head" slot="head" />
   <article>
     <h1>{title}</h1>
-    <p class="post-meta">{isoDate}</p>
+    <p class="post-meta"><time datetime={isoDate}>{isoDate}</time></p>
     <slot />
   </article>
   <p class="back-link"><a href="/blog/">← All Writing</a></p>

--- a/src/legacy/posts.ts
+++ b/src/legacy/posts.ts
@@ -1,0 +1,74 @@
+import diagrammerBody from './2017-10-17-thinking-in-systems-with-diagrammer.html?raw';
+import rhymerBody from './2017-12-23-introducing-rhymer.html?raw';
+import replyAllBody from './2019-02-02-web-scraping-reply-all-transcripts.html?raw';
+
+export interface HeadAsset {
+  type: 'script' | 'style';
+  href: string;
+}
+
+export interface FrozenPost {
+  slug: string;
+  url: string;
+  title: string;
+  date: Date;
+  description: string;
+  body: string;
+  headAssets: HeadAsset[];
+}
+
+export const frozenPosts: FrozenPost[] = [
+  {
+    slug: 'web-scraping-reply-all-transcripts',
+    url: '/blog/post/web-scraping-reply-all-transcripts/',
+    title: 'Web scraping Reply All transcripts',
+    date: new Date('2019-02-02'),
+    description: 'Scraping every Reply All episode transcript with rvest, then exploring the corpus with tidytext.',
+    body: replyAllBody,
+    headAssets: [
+      { type: 'script', href: '/rmarkdown-libs/kePrint/kePrint.js' },
+    ],
+  },
+  {
+    slug: 'introducing-rhymer',
+    url: '/blog/post/introducing-rhymer/',
+    title: 'Introducing rhymer',
+    date: new Date('2017-12-23'),
+    description: 'Announcing rhymer, an R package that wraps the Datamuse API to find rhyming words.',
+    body: rhymerBody,
+    headAssets: [],
+  },
+  {
+    slug: 'thinking-in-systems-with-diagrammer',
+    url: '/blog/post/thinking-in-systems-with-diagrammer/',
+    title: 'Thinking in Systems with DiagrammeR',
+    date: new Date('2017-10-17'),
+    description: "Replicating stock-and-flow diagrams from Donella Meadows' Thinking in Systems using DiagrammeR in R.",
+    body: diagrammerBody,
+    headAssets: [
+      { type: 'style', href: '/rmarkdown-libs/DiagrammeR-styles/styles.css' },
+      { type: 'script', href: '/rmarkdown-libs/htmlwidgets/htmlwidgets.js' },
+      { type: 'script', href: '/rmarkdown-libs/viz/viz.js' },
+      { type: 'script', href: '/rmarkdown-libs/grViz-binding/grViz.js' },
+    ],
+  },
+];
+
+export const frozenPostsBySlug: Record<string, FrozenPost> = Object.fromEntries(
+  frozenPosts.map((p) => [p.slug, p]),
+);
+
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Browsers don't execute <script>/parse <link> tags inserted via set:html,
+// so each frozen post re-emits its head assets via the BaseLayout "head"
+// slot and strips the body's copies here to avoid duplicate tags.
+export function stripHeadAssets(body: string, assets: HeadAsset[]): string {
+  return assets.reduce((b, asset) => {
+    const escaped = escapeRegex(asset.href);
+    const pattern = asset.type === 'script'
+      ? new RegExp(`<script src="${escaped}"></script>\\s*`)
+      : new RegExp(`<link href="${escaped}" rel="stylesheet" />\\s*`);
+    return b.replace(pattern, '');
+  }, body);
+}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,32 +1,9 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { frozenPosts } from '../../legacy/posts';
 
 const collectionPosts = await getCollection('blog', ({ data }) => !data.draft);
-
-// Frozen R-rendered posts — preserved at their original Hugo URLs.
-// They live as standalone .astro pages under src/pages/blog/post/, not in
-// the content collection, but we list them here so they appear in the index.
-const frozenPosts = [
-  {
-    title: 'Web scraping Reply All transcripts',
-    date: new Date('2019-02-02'),
-    url: '/blog/post/web-scraping-reply-all-transcripts/',
-    description: 'Scraping every Reply All episode transcript with rvest, then exploring the corpus with tidytext.',
-  },
-  {
-    title: 'Introducing rhymer',
-    date: new Date('2017-12-23'),
-    url: '/blog/post/introducing-rhymer/',
-    description: 'Announcing rhymer, an R package that wraps the Datamuse API to find rhyming words.',
-  },
-  {
-    title: 'Thinking in Systems with DiagrammeR',
-    date: new Date('2017-10-17'),
-    url: '/blog/post/thinking-in-systems-with-diagrammer/',
-    description: "Replicating stock-and-flow diagrams from Donella Meadows' Thinking in Systems using DiagrammeR in R.",
-  },
-];
 
 const allPosts = [
   ...collectionPosts.map((p) => ({
@@ -35,7 +12,12 @@ const allPosts = [
     url: `/blog/${p.data.permalink}/`,
     description: p.data.description,
   })),
-  ...frozenPosts,
+  ...frozenPosts.map((p) => ({
+    title: p.title,
+    date: p.date,
+    url: p.url,
+    description: p.description,
+  })),
 ].sort((a, b) => b.date.getTime() - a.date.getTime());
 
 const iso = (d: Date) => d.toISOString().slice(0, 10);

--- a/src/pages/blog/post/introducing-rhymer.astro
+++ b/src/pages/blog/post/introducing-rhymer.astro
@@ -1,12 +1,6 @@
 ---
-import PostLayout from '../../../layouts/PostLayout.astro';
-import body from '../../../legacy/2017-12-23-introducing-rhymer.html?raw';
+import FrozenPost from '../../../components/FrozenPost.astro';
+import { frozenPostsBySlug } from '../../../legacy/posts';
 ---
 
-<PostLayout
-  title="Introducing rhymer"
-  date="2017-12-23"
-  description="Announcing rhymer, an R package that wraps the Datamuse API to find rhyming words."
->
-  <Fragment set:html={body} />
-</PostLayout>
+<FrozenPost post={frozenPostsBySlug['introducing-rhymer']} />

--- a/src/pages/blog/post/thinking-in-systems-with-diagrammer.astro
+++ b/src/pages/blog/post/thinking-in-systems-with-diagrammer.astro
@@ -1,30 +1,6 @@
 ---
-import PostLayout from '../../../layouts/PostLayout.astro';
-import body from '../../../legacy/2017-10-17-thinking-in-systems-with-diagrammer.html?raw';
-
-// External scripts and CSS that the DiagrammeR htmlwidget depends on must
-// live in <head> so the browser actually executes them — scripts inserted
-// via set:html below are parsed but not executed by the browser.
-// The inline <script type="application/json"> data blocks in the body
-// are non-executing data containers, read by the htmlwidgets framework
-// via DOM queries, so set:html-insertion is fine for those.
-const cleanedBody = body
-  .replace(/<script src="\/rmarkdown-libs\/htmlwidgets\/htmlwidgets\.js"><\/script>\s*/, '')
-  .replace(/<script src="\/rmarkdown-libs\/viz\/viz\.js"><\/script>\s*/, '')
-  .replace(/<link href="\/rmarkdown-libs\/DiagrammeR-styles\/styles\.css" rel="stylesheet" \/>\s*/, '')
-  .replace(/<script src="\/rmarkdown-libs\/grViz-binding\/grViz\.js"><\/script>\s*/, '');
+import FrozenPost from '../../../components/FrozenPost.astro';
+import { frozenPostsBySlug } from '../../../legacy/posts';
 ---
 
-<PostLayout
-  title="Thinking in Systems with DiagrammeR"
-  date="2017-10-17"
-  description="Replicating stock-and-flow diagrams from Donella Meadows' Thinking in Systems using DiagrammeR in R."
->
-  <Fragment slot="head">
-    <link href="/rmarkdown-libs/DiagrammeR-styles/styles.css" rel="stylesheet" />
-    <script src="/rmarkdown-libs/htmlwidgets/htmlwidgets.js" is:inline></script>
-    <script src="/rmarkdown-libs/viz/viz.js" is:inline></script>
-    <script src="/rmarkdown-libs/grViz-binding/grViz.js" is:inline></script>
-  </Fragment>
-  <Fragment set:html={cleanedBody} />
-</PostLayout>
+<FrozenPost post={frozenPostsBySlug['thinking-in-systems-with-diagrammer']} />

--- a/src/pages/blog/post/web-scraping-reply-all-transcripts.astro
+++ b/src/pages/blog/post/web-scraping-reply-all-transcripts.astro
@@ -1,21 +1,6 @@
 ---
-import PostLayout from '../../../layouts/PostLayout.astro';
-import body from '../../../legacy/2019-02-02-web-scraping-reply-all-transcripts.html?raw';
-
-// kePrint binding for the kable tables in this post — must be in <head>.
-const cleanedBody = body.replace(
-  /<script src="\/rmarkdown-libs\/kePrint\/kePrint\.js"><\/script>\s*/,
-  ''
-);
+import FrozenPost from '../../../components/FrozenPost.astro';
+import { frozenPostsBySlug } from '../../../legacy/posts';
 ---
 
-<PostLayout
-  title="Web scraping Reply All transcripts"
-  date="2019-02-02"
-  description="Scraping every Reply All episode transcript with rvest, then exploring the corpus with tidytext."
->
-  <Fragment slot="head">
-    <script src="/rmarkdown-libs/kePrint/kePrint.js" is:inline></script>
-  </Fragment>
-  <Fragment set:html={cleanedBody} />
-</PostLayout>
+<FrozenPost post={frozenPostsBySlug['web-scraping-reply-all-transcripts']} />

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -3,14 +3,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Projects — Noah Landesberg" description="Projects by Noah Landesberg.">
-  <h2><a class="project-link" href="https://github.com/landesbergn/rhymer">rhymer<span class="arrow">↗</span></a></h2>
+  <h2><a class="project-link" href="https://github.com/landesbergn/rhymer">rhymer<span class="arrow" aria-hidden="true">↗</span></a></h2>
   <p>
     An R package to find rhyming words. A wrapper around the
     <a href="https://www.datamuse.com/api">Datamuse API</a>, published on
     <a href="https://cran.r-project.org/package=rhymer">CRAN</a>.
   </p>
 
-  <h2><a class="project-link" href="https://github.com/landesbergn/feels-like">Feels Like<span class="arrow">↗</span></a></h2>
+  <h2><a class="project-link" href="https://github.com/landesbergn/feels-like">Feels Like<span class="arrow" aria-hidden="true">↗</span></a></h2>
   <p>
     The first and only weather app for iOS focused on letting you know what it
     feels like before you venture outdoors. Apple rejected it from the App Store
@@ -19,7 +19,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     beta testers cumulatively averaged 450 uses per month.
   </p>
 
-  <h2><a class="project-link" href="https://github.com/landesbergn/nyc_restaurants">NYC Bar &amp; Restaurant Closings<span class="arrow">↗</span></a></h2>
+  <h2><a class="project-link" href="https://github.com/landesbergn/nyc_restaurants">NYC Bar &amp; Restaurant Closings<span class="arrow" aria-hidden="true">↗</span></a></h2>
   <p>
     A "database" of various NYC bar &amp; restaurant closings since COVID-19
     radically changed the restaurant landscape. Includes the scraping scripts

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -208,10 +208,6 @@ body {
   }
 }
 
-main {
-  display: block;
-}
-
 main > *:first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- Hoist the 3 frozen R-rendered posts' metadata, body imports, and head-asset declarations into `src/legacy/posts.ts` (single source of truth, with a shared `stripHeadAssets` helper)
- Add `src/components/FrozenPost.astro` so each per-post page collapses to ~6 lines and the blog index imports the same array instead of redeclaring it
- `PostLayout` takes `Date` directly (drops the `string | Date` union) and wraps the post date in a `<time datetime="…">` element
- `aria-hidden="true"` on the project page `↗` arrows so screen readers don't announce "up-right arrow"
- Remove no-op `main { display: block }` from global.css

No content, routing, or visual changes — every URL renders the same HTML aside from the new `<time>` wrapper and the `aria-hidden` attribute.

## Test plan
- [x] `npm run build` succeeds; all 11 pages generated
- [x] Diagrammer page emits 4 head assets exactly once each (no body duplicates)
- [x] Reply All page emits `kePrint.js` exactly once (no body duplicate)
- [x] Rhymer page has zero `rmarkdown-libs` references (none expected)
- [x] Blog index lists all 7 posts in chronological order
- [x] Project arrows have `aria-hidden="true"` in rendered HTML
- [x] Markdown post renders `<time datetime="…">…</time>` inside `.post-meta`
- [x] Click through Netlify deploy preview: home, projects, /blog/, all 7 post URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)