### PR TITLE
Add MarketFlip to projects and bio

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,8 +13,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   <p>
     In my spare time I enjoy building software that is mostly useless, including
-    an <a href="https://landesbergn.github.io/rhymer/index.html">R package for finding rhyming words</a>
-    and an iOS app that tells you what it
-    <a href="https://github.com/landesbergn/feels-like">"feels like"</a> outside.
+    an <a href="https://landesbergn.github.io/rhymer/index.html">R package for finding rhyming words</a>,
+    an iOS app that tells you what it
+    <a href="https://github.com/landesbergn/feels-like">"feels like"</a> outside,
+    and <a href="https://marketflip.xyz">marketflip.xyz</a>, a site that flips
+    a coin weighted to live Polymarket odds.
   </p>
 </BaseLayout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -3,6 +3,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Projects — Noah Landesberg" description="Projects by Noah Landesberg.">
+  <h2><a class="project-link" href="https://github.com/landesbergn/marketflip">MarketFlip<span class="arrow" aria-hidden="true">↗</span></a></h2>
+  <p>
+    Flip a coin weighted to a live Polymarket market's implied odds — once,
+    or a hundred times. Built with Next.js and TypeScript. Live at
+    <a href="https://marketflip.xyz">marketflip.xyz</a>.
+  </p>
+
   <h2><a class="project-link" href="https://github.com/landesbergn/rhymer">rhymer<span class="arrow" aria-hidden="true">↗</span></a></h2>
   <p>
     An R package to find rhyming words. A wrapper around the

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -5,8 +5,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="Projects — Noah Landesberg" description="Projects by Noah Landesberg.">
   <h2><a class="project-link" href="https://github.com/landesbergn/marketflip">MarketFlip<span class="arrow" aria-hidden="true">↗</span></a></h2>
   <p>
-    Flip a coin weighted to a live Polymarket market's implied odds — once,
-    or a hundred times. Built with Next.js and TypeScript. Live at
+    Flip a coin weighted to a live Polymarket market's implied odds. Live at
     <a href="https://marketflip.xyz">marketflip.xyz</a>.
   </p>
 


### PR DESCRIPTION
## Summary
- Adds [marketflip.xyz](https://marketflip.xyz) (a coin-flip simulator weighted to live Polymarket odds, [repo](https://github.com/landesbergn/marketflip)) as the top entry on `/projects`.
- Mentions it as a third spare-time project in the homepage bio.

## Test plan
- [x] `npm run build` passes
- [ ] Skim the Netlify deploy preview for `/` and `/projects/` — confirm the new copy renders and both links resolve