### PR TITLE
Friendlier error when Talk to me can't connect

### DIFF
--- a/src/components/TalkToMe.astro
+++ b/src/components/TalkToMe.astro
@@ -41,23 +41,32 @@ const agentId = import.meta.env.PUBLIC_ELEVENLABS_AGENT_ID;
       }
     }
 
+    // Server-side close with no useful message (the common case for quota
+    // exhaustion: LiveKit signaling drops with an empty WS reason). We can't
+    // tell quota apart from agent-config / network rejection from the SDK
+    // surface, so we show one friendly default that mentions the likely cause.
+    const CONNECT_FAILED = "Couldn't connect — daily call limit may be reached. Try again later.";
+
     async function start() {
       setState("connecting", "Connecting…");
       setStatus(null);
+      let hasConnected = false;
       try {
         session.current = await Conversation.startSession({
           agentId,
-          onConnect: () => setState("listening", "End conversation"),
-          onDisconnect: () => {
+          onConnect: () => {
+            hasConnected = true;
+            setState("listening", "End conversation");
+          },
+          onDisconnect: (details: { reason: "error" | "agent" | "user" }) => {
             session.current = null;
+            if (details.reason === "error" && !hasConnected) {
+              setStatus(CONNECT_FAILED);
+            }
             setState("idle", "Talk to me");
           },
-          onError: (err: unknown) => {
-            console.error("ElevenLabs error:", err);
-            const msg = err instanceof Error ? err.message : String(err);
-            setStatus(`Couldn't connect: ${msg}`);
-            session.current = null;
-            setState("idle", "Talk to me");
+          onError: (message: string, context?: unknown) => {
+            console.error("ElevenLabs error:", message, context);
           },
           onModeChange: ({ mode }: { mode: "speaking" | "listening" }) => {
             setState(mode, "End conversation");
@@ -65,8 +74,10 @@ const agentId = import.meta.env.PUBLIC_ELEVENLABS_AGENT_ID;
         });
       } catch (err: unknown) {
         console.error("Start failed:", err);
-        const msg = err instanceof Error ? err.message : String(err);
-        setStatus(`Couldn't connect: ${msg}`);
+        const micDenied = err instanceof DOMException && err.name === "NotAllowedError";
+        setStatus(micDenied
+          ? "Microphone access denied. Allow mic in your browser and try again."
+          : CONNECT_FAILED);
         setState("idle", "Talk to me");
       }
     }


### PR DESCRIPTION
## Summary
- Show "Couldn't connect — daily call limit may be reached. Try again later." instead of the raw SDK error when ElevenLabs closes the signaling WS without a reason (common cause: daily/monthly minute cap hit).
- Track `hasConnected` and route user-facing copy through `onDisconnect` (typed `reason: "error" | "agent" | "user"`); `onError` becomes log-only so non-fatal mid-call errors don't reset the button.
- Distinguish mic-permission denial (DOMException `NotAllowedError`) so denying the browser prompt doesn't say "limit reached."

Context: hit the 20-call daily cap during testing; saw the wall of LiveKit `DataChannel error` / empty WS close / `createOffer with closed peer connection` cascades while the UI just showed the raw error string. Diagnosis was server-side termination, not a code bug — this PR makes the failure mode legible.

## Test plan
- [ ] Deploy preview renders Home page and the Talk to me button.
- [ ] Click Talk to me, allow mic — normal call flow (button → "End conversation").
- [ ] Click Talk to me, deny mic — status reads "Microphone access denied. Allow mic in your browser and try again."
- [ ] (If reproducible) trigger a quota / agent-side failure — status reads the daily-limit hint, button returns to idle.
- [ ] End a call via the button — no status message appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)