### PR TITLE
Replace monospace UI chrome with Jost (libre Futura)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig, fontProviders } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
@@ -8,4 +8,18 @@ export default defineConfig({
     format: 'directory',
   },
   integrations: [sitemap()],
+  // Jost (a libre Futura clone) for UI chrome — nav, dates, post-meta.
+  // Astro downloads and self-hosts it at build time, so there's no runtime
+  // request to Google and every visitor gets the identical font. Exposed as
+  // the --font-jost CSS variable, consumed via --font-ui in global.css.
+  fonts: [
+    {
+      provider: fontProviders.google(),
+      name: 'Jost',
+      cssVariable: '--font-jost',
+      weights: [400, 700],
+      styles: ['normal'],
+      subsets: ['latin'],
+    },
+  ],
 });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import { Font } from 'astro:assets';
 
 interface Props {
   title: string;
@@ -25,6 +26,7 @@ const titleLetters = Array.from('Noah Landesberg');
     <link rel="icon" type="image/png" href="/image/favicon.png" />
     <link rel="canonical" href={new URL(pathname, Astro.site).toString()} />
     <title>{title}</title>
+    <Font cssVariable="--font-jost" preload />
     <slot name="head" />
   </head>
   <body>

--- a/src/pages/lately.astro
+++ b/src/pages/lately.astro
@@ -261,7 +261,7 @@ const iso = (d: Date | string) => new Date(d).toISOString().slice(0, 10);
     opacity: 1;
   }
   .lately-entry time {
-    font-family: var(--font-mono);
+    font-family: var(--font-ui);
     font-size: 0.8rem;
     color: var(--color-muted);
     font-variant-numeric: tabular-nums;
@@ -308,7 +308,7 @@ const iso = (d: Date | string) => new Date(d).toISOString().slice(0, 10);
     top: -0.15em;
   }
   .lately-writing-list time {
-    font-family: var(--font-mono);
+    font-family: var(--font-ui);
     font-size: 0.8rem;
     color: var(--color-muted);
     font-variant-numeric: tabular-nums;
@@ -346,7 +346,7 @@ const iso = (d: Date | string) => new Date(d).toISOString().slice(0, 10);
   .pane-caption {
     flex-shrink: 0;
     margin-top: 10px;
-    font-family: var(--font-mono);
+    font-family: var(--font-ui);
     font-size: 0.8rem;
     color: var(--color-muted);
     line-height: 1.5;
@@ -406,7 +406,7 @@ const iso = (d: Date | string) => new Date(d).toISOString().slice(0, 10);
       padding: 4px 2px;
       margin-left: 4px;
       color: var(--color-accent);
-      font-family: var(--font-mono);
+      font-family: var(--font-ui);
       font-size: 0.78rem;
       cursor: pointer;
       min-height: 32px;
@@ -427,7 +427,7 @@ const iso = (d: Date | string) => new Date(d).toISOString().slice(0, 10);
       display: block;
     }
     .mobile-caption {
-      font-family: var(--font-mono);
+      font-family: var(--font-ui);
       font-size: 0.78rem;
       color: var(--color-muted);
       margin-top: 4px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,7 +124,9 @@ body {
   flex-wrap: wrap;
   min-height: 44px;            /* tap-target row height */
   font-family: var(--font-ui);
-  font-size: 0.85rem;
+  /* Jost has a smaller x-height than the old monospace, so it reads small
+     at the same size — bump the nav up a notch to compensate. */
+  font-size: 0.95rem;
   color: var(--color-muted);
   row-gap: 4px;
 }
@@ -219,7 +221,7 @@ body {
    step down further and drop the separators. */
 @media (max-width: 540px) {
   .site-header nav {
-    font-size: 0.85rem;
+    font-size: 0.9rem;
   }
   .site-header nav a {
     padding: 0 4px;
@@ -241,7 +243,7 @@ body {
 
 @media (max-width: 380px) {
   .site-header nav {
-    font-size: 0.72rem;
+    font-size: 0.8rem;
   }
   .site-header nav .sep {
     display: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,11 @@
 
   --font-serif: 'Iowan Old Style', 'Charter', 'Source Serif 4', Georgia, 'Times New Roman', Times, serif;
   --font-mono: ui-monospace, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', Consolas, 'Courier New', Courier, monospace;
+
+  /* UI chrome (nav, dates, post-meta, back-link). Jost is a libre Futura
+     clone, self-hosted via Astro's Fonts API (--font-jost). Falls back to
+     a geometric sans so labels stay on-brand before/if the font loads. */
+  --font-ui: var(--font-jost, 'Jost'), 'Avenir Next', 'Avenir', 'Century Gothic', system-ui, sans-serif;
 }
 
 * {
@@ -118,7 +123,7 @@ body {
   align-items: center;
   flex-wrap: wrap;
   min-height: 44px;            /* tap-target row height */
-  font-family: var(--font-mono);
+  font-family: var(--font-ui);
   font-size: 0.85rem;
   color: var(--color-muted);
   row-gap: 4px;
@@ -531,7 +536,7 @@ article .html-widget svg {
 
 .post-list time {
   color: var(--color-muted);
-  font-family: var(--font-mono);
+  font-family: var(--font-ui);
   font-size: 0.85rem;
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;


### PR DESCRIPTION
## What & why

The site used **monospace** for all its UI chrome — nav, dates, post-meta, the back-link, and the whole **Lately** timeline. It read as overly "techy." This swaps that chrome to **Jost**, an open-source **Futura** clone, for a warmer, more human feel — while leaving monospace exactly where it belongs (code).

## Changes

- **`global.css`** — new `--font-ui` token (Jost + geometric-sans fallback chain); the four chrome rules (`nav`, `.post-list time`, `.post-meta`, `.back-link`) now use it.
- **`lately.astro`** — the five date/meta rules switched to `--font-ui`.
- **`astro.config.mjs`** — Jost registered via Astro's built-in **Fonts API** (`fontProviders.google()`), so it's **downloaded and self-hosted at build time**: identical rendering on every OS, no runtime request to Google, and an auto-generated metric-matched fallback to minimize layout shift.
- **`BaseLayout.astro`** — `<Font preload />` in `<head>`.

## Stays monospace (deliberately)

Code blocks, inline `code`, and blog **data tables** — mono is correct there. Also untouched: the Talk-to-me error text and the devtools `console.log` greeting.

## Compatibility

Jost is self-hosted, so **every visitor on every OS gets the identical font** (the requirement that ruled out Apple-only Futura/Avenir). One small ~10–15 KB latin woff2 slice is fetched per visitor; text stays readable in the fallback while it loads.

## Verification

`npm run build` (with network) emits the `@font-face` rules + latin woff2 slices, and the `--font-ui → --font-jost` chain resolves in the built CSS. The deploy preview on this PR is the real check.

> Note: the Fonts API fetches from Google **at build time** — Netlify builds have network so this is fine. A sandbox without network will build successfully but skip the font (graceful fallback to the geometric chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)