### PR TITLE
Bump vite 7.3.2 → 7.3.5 (clears Dependabot alerts #15, #16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5313,9 +5313,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
## What

Bumps the transitive `vite` dependency **7.3.2 → 7.3.5** (lockfile-only). vite is pulled in by Astro (`^7.3.2`), not declared in our `package.json`, so Dependabot can't express the fix as a manifest edit and won't auto-open a PR — hence by hand.

## Why

Clears the two open Dependabot alerts, both patched in vite 7.3.5:

| Alert | Severity | Issue |
|-------|----------|-------|
| #15 | High | `server.fs.deny` bypass on Windows alternate paths |
| #16 | Medium | `launch-editor` NTLMv2 hash disclosure via UNC paths on Windows |

Both are **Windows-only, dev-server-only** — they don't touch the static production build on Netlify. Low real-world risk, but no reason to leave them open when the fix is free.

## Compatibility

Astro 6.4.6's range is `"vite": "^7.3.2"`, which already permits 7.3.5 — no Astro change, no manifest change, build behavior unchanged.

## Verification

- `npm run build` → clean, 12 pages built
- `npm audit` → 0 vulnerabilities
- Diff is `package-lock.json` only (+3 −3: vite version, resolved URL, integrity)

Alerts #15 and #16 close automatically once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)